### PR TITLE
Fix repository for github-push-action to restatedev/homebrew-tap 

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,3 +26,4 @@ jobs:
         uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.HOMEBREW_TAP_CONTENTS_WRITE || secrets.GITHUB_TOKEN }}
+          repository: restatedev/homebrew-tap

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,6 +23,6 @@ jobs:
           git config user.email "<>"
       - run: ./release/release.sh
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.HOMEBREW_TAP_CONTENTS_WRITE || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes https://github.com/restatedev/homebrew-tap/issues/3.