### PR TITLE
fix: usage of `a deprecated Node.js version`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: restatedev/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_CONTENTS_WRITE || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes https://github.com/restatedev/restate/issues/2380